### PR TITLE
Fix bug #1996 - fix compatibility with django-tables2 >= 1.0.6

### DIFF
--- a/dashboard_app/views/__init__.py
+++ b/dashboard_app/views/__init__.py
@@ -85,7 +85,6 @@ from dashboard_app.views.filters.tables import PublicFiltersTable
 from dashboard_app.views.image_reports.tables import UserImageReportTable
 
 from django_tables2 import (
-    Attrs,
     Column,
     RequestConfig,
     SingleTableView,


### PR DESCRIPTION
Attrs were removed from django-tables2 in
6c5b36c6a54eb69e23e4ae5f8998e94d5585e0da

Signed-off-by: Petr Vorel petr.vorel@gmail.com
