### PR TITLE
Add nbdroot as optional parameter to the schema

### DIFF
--- a/lava_scheduler_app/schema.py
+++ b/lava_scheduler_app/schema.py
@@ -20,6 +20,7 @@ def _deploy_tftp_schema():
         Required('to'): 'tftp',
         Optional('kernel'): {Required('url'): str},
         Optional('ramdisk'): {Required('url'): str},
+        Optional('nbdroot'): {Required('url'): str},
         Optional('nfsrootfs'): {Required('url'): str},
         Optional('dtb'): {Required('url'): str},
     }, extra=True)


### PR DESCRIPTION
NBDroot support allows to serve filesystem images to the
target through e.g. xnbd server. This is required if
the system uses XATTR in filesystems (not supported by NFS).

Signed-off-by: Jan-Simon Möller dl9pf@gmx.de
