### PR TITLE
Add support for the NextThing CHIP Pro

### DIFF
--- a/lava_scheduler_app/tests/device-types/sun5i-gr8-chip-pro.jinja2
+++ b/lava_scheduler_app/tests/device-types/sun5i-gr8-chip-pro.jinja2
@@ -1,0 +1,11 @@
+{% extends 'base-uboot.jinja2' %}
+{% set console_device = console_device|default('ttyS0') %}
+{% set baud_rate = baud_rate|default(115200) %}
+{% set device_type = "sun5i-gr8-chip-pro" %}
+{% set bootloader_prompt = bootloader_prompt|default('=>') %}
+{% set bootz_kernel_addr = '0x42000000' %}
+{% set bootz_ramdisk_addr = '0x43300000' %}
+{% set bootz_dtb_addr = '0x43000000' %}
+{% set base_ip_args = 'ip=dhcp' %}
+{% set uboot_mkimage_arch = 'arm' %}
+{% set uboot_needs_usb = true %}


### PR DESCRIPTION
This device uses upstream U-Boot, so it's pretty standard.

Signed-off-by: Maxime Ripard <maxime.ripard@free-electrons.com>